### PR TITLE
added detection for window global

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,5 +3,6 @@
 module.exports = isJsObject;
 
 function isJsObject(obj) {
-  return Object.prototype.toString.call(obj) === '[object Object]';
+  return /^\[object (?:object|global)\]$/i
+    .test(Object.prototype.toString.call(obj));
 }

--- a/test.js
+++ b/test.js
@@ -7,6 +7,7 @@ test('should test valids JS Objects', function(assert) {
   assert.deepEqual(isJsObject({a: 1}), true);
   /*jshint -W010 */
   assert.deepEqual(isJsObject(new Object()), true);
+  assert.deepEqual(isJsObject(global), true);
   assert.end();
 });
 


### PR DESCRIPTION
make isJsObject pass when object is a global (ex. `window` or node `global`).
Fixes #1 
