### PR TITLE
Make it work in Firefox & Safari

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,6 @@
 module.exports = isJsObject;
 
 function isJsObject(obj) {
-  return /^\[object (?:object|global)\]$/i
+  return /^\[object (?:object|global|window)\]$/i
     .test(Object.prototype.toString.call(obj));
 }


### PR DESCRIPTION
Firefox returns `[object Window]` if object is window
